### PR TITLE
Fix version

### DIFF
--- a/leap_data_management_utils/__init__.py
+++ b/leap_data_management_utils/__init__.py
@@ -8,3 +8,8 @@ __all__ = (
     'CMIPBQInterface',
     'LogCMIPToBigQuery',
 )
+
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "unknown"

--- a/leap_data_management_utils/__init__.py
+++ b/leap_data_management_utils/__init__.py
@@ -12,4 +12,4 @@ __all__ = (
 try:
     from ._version import __version__
 except ImportError:
-    __version__ = "unknown"
+    __version__ = 'unknown'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ test = [
     "pre-commit",
 ]
 
+[tool.setuptools_scm]
+write_to = "leap-data-management-utils/_version.py"
+write_to_template = "__version__ = '{version}'"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
Got a failure on release [here](https://github.com/leap-stc/leap-data-management-utils/actions/runs/8711511550). I am not sure that actually worked before? Trying to fix this here. 

I think there are two issues. 
- [x] The version is not parsed properly (see [here](https://github.com/leap-stc/leap-data-management-utils/actions/runs/8711511550/job/23895755039#step:5:156))
- [x] I think the pypi auth token was never set (or got lost during the transfer). 

