### PR TITLE
add catalog functionality

### DIFF
--- a/.github/workflows/catalog-ci.yaml
+++ b/.github/workflows/catalog-ci.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Validate Feedstocks and Generate Catalog
         run: |
           leap-catalog --help
+          leap-catalog validate --single https://github.com/leap-stc/proto_feedstock/blob/main/feedstock/catalog.yaml
           leap-catalog generate --path https://raw.githubusercontent.com/leap-stc/data-management/staging/catalog/input.yaml --output catalog/
           cat catalog/output/consolidated-web-catalog.json | jq
 

--- a/.github/workflows/catalog-ci.yaml
+++ b/.github/workflows/catalog-ci.yaml
@@ -1,0 +1,43 @@
+name: Catalog
+
+on:
+  pull_request:
+    branches:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate-and-validate:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v4
+      - name: set up conda environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: ci/environment.yaml
+          init-shell: >-
+            bash
+          cache-environment: true
+          cache-downloads: true
+          post-cleanup: "all"
+
+      - name: Install package
+        run: |
+          python -m pip install .
+
+      - name: Validate Feedstocks and Generate Catalog
+        run: |
+          leap-catalog --help
+          leap-catalog --path https://raw.githubusercontent.com/leap-stc/data-management/staging/catalog/input.yaml --output catalog/
+          cat catalog/output/consolidated-web-catalog.json | jq
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: consolidated-web-catalog.json
+          path: catalog/output/consolidated-web-catalog.json

--- a/.github/workflows/catalog-ci.yaml
+++ b/.github/workflows/catalog-ci.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Validate Feedstocks and Generate Catalog
         run: |
           leap-catalog --help
-          leap-catalog --path https://raw.githubusercontent.com/leap-stc/data-management/staging/catalog/input.yaml --output catalog/
+          leap-catalog generate --path https://raw.githubusercontent.com/leap-stc/data-management/staging/catalog/input.yaml --output catalog/
           cat catalog/output/consolidated-web-catalog.json | jq
 
       - name: Upload artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+_version.py

--- a/ci/environment.yaml
+++ b/ci/environment.yaml
@@ -1,0 +1,27 @@
+name: leap-data-management
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.10
+  - aiohttp
+  - apache-beam
+  - black
+  - cftime
+  - google-cloud-bigquery
+  - fsspec >= 2023.2
+  - gcsfs
+  - google-api-core
+  - pangeo-forge-recipes
+  - pre-commit
+  - pydantic-core
+  - pydantic>=2
+  - pytest
+  - pyyaml
+  - ruff
+  - s3fs
+  - universal_pathlib
+  - zarr
+  - pip:
+      - db_dtypes
+      - pangeo-forge-esgf

--- a/leap_data_management_utils/catalog.py
+++ b/leap_data_management_utils/catalog.py
@@ -1,0 +1,158 @@
+import argparse
+import json
+import traceback
+
+import pydantic
+import pydantic_core
+import upath
+import yaml
+
+
+class Store(pydantic.BaseModel):
+    id: str = pydantic.Field(..., description='ID of the store')
+    name: str = pydantic.Field(None, description='Name of the store')
+    url: str = pydantic.Field(..., description='URL of the store')
+    rechunking: list[dict[str, str]] | None = pydantic.Field(None, alias='ncviewjs:rechunking')
+
+
+class Link(pydantic.BaseModel):
+    label: str = pydantic.Field(..., description='Label of the link')
+    url: str = pydantic.Field(..., description='URL of the link')
+
+
+class LicenseLink(pydantic.BaseModel):
+    title: str = pydantic.Field(..., description='Name of the license')
+    url: str | None = pydantic.Field(None, description='URL of the license')
+
+
+class Maintainer(pydantic.BaseModel):
+    name: str = pydantic.Field(..., description='Name of the maintainer')
+    github: str | None = pydantic.Field(None, description='GitHub username of the maintainer')
+
+
+class Provider(pydantic.BaseModel):
+    name: str = pydantic.Field(..., description='Name of the provider')
+    description: str | None = pydantic.Field(None, description='Description of the provider')
+    roles: list[str] | None = pydantic.Field(None, description='Roles of the provider')
+    url: str | None = pydantic.Field(None, description='URL of the provider')
+
+
+class Provenance(pydantic.BaseModel):
+    providers: list[Provider]
+    license: str
+    license_link: LicenseLink | None = None
+
+
+class Feedstock(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(validate_assignment=True)
+
+    title: str = pydantic.Field(..., description='Title of the feedstock')
+    description: str = pydantic.Field(..., description='Description of the feedstock')
+    maintainers: list[Maintainer]
+    provenance: Provenance
+    thumbnail: pydantic.HttpUrl | None = pydantic.Field(
+        None, description='Thumbnail of the feedstock'
+    )
+    tags: list[str] | None = pydantic.Field(None, description='Tags of the dataset')
+    links: list[Link] | None = None
+    stores: list[Store] | None = None
+    meta_yaml_url: pydantic.HttpUrl | None = pydantic.Field(None, alias='ncviewjs:meta_yaml_url')
+
+    @classmethod
+    def from_yaml(cls, path: str):
+        content = yaml.safe_load(upath.UPath(path).read_text())
+        if 'ncviewjs:meta_yaml_url' in content:
+            meta_url = convert_to_raw_github_url(content['ncviewjs:meta_yaml_url'])
+            meta = yaml.safe_load(upath.UPath(meta_url).read_text())
+            content = content | meta
+        data = cls.model_validate(content)
+        return data
+
+
+def convert_to_raw_github_url(github_url):
+    # Check if the URL is already a raw URL
+    if 'raw.githubusercontent.com' in github_url:
+        return github_url
+
+    # Replace the domain
+    raw_url = github_url.replace('github.com', 'raw.githubusercontent.com')
+
+    # Remove '/blob'
+    raw_url = raw_url.replace('/blob', '')
+
+    return raw_url
+
+
+class ValidationError(Exception):
+    def __init__(self, errors: list[dict[str, str]] | str) -> None:
+        self.errors = errors
+        super().__init__(self.errors)
+
+
+def collect_feedstocks(path: upath.UPath) -> list[upath.UPath]:
+    """Collects all the datasets in the given directory."""
+
+    url = convert_to_raw_github_url(path)
+    if not (feedstocks := yaml.safe_load(upath.UPath(url).read_text())['feedstocks']):
+        raise FileNotFoundError(f'No YAML files (.yaml or .yml) found in {path}')
+    print(feedstocks)
+    return feedstocks
+
+
+def validate_feedstocks(*, feedstocks: upath.UPath) -> list[Feedstock]:
+    def format_report(title: str, feedstocks: list[dict], include_traceback: bool = False) -> str:
+        report = f'{title} ({len(feedstocks)})\n'
+        if not feedstocks:
+            report += '  🚀 None found\n'
+        else:
+            for entry in feedstocks:
+                report += f"  📂 {entry['feedstock']}\n"
+                if include_traceback:
+                    report += f"    🔎 {entry['traceback']}\n"
+        return report
+
+    errors = []
+    valid = []
+    catalog = []
+
+    for feedstock in feedstocks:
+        try:
+            feed = Feedstock.from_yaml(convert_to_raw_github_url(feedstock))
+            valid.append({'feedstock': str(feedstock), 'status': 'valid'})
+            catalog.append(feed)
+        except Exception:
+            errors.append({'feedstock': str(feedstock), 'traceback': traceback.format_exc()})
+
+    valid_report = format_report('✅ Valid feedstocks:', valid)
+    invalid_report = format_report('❌ Invalid feedstocks:', errors, include_traceback=True)
+
+    print(valid_report)
+    print(invalid_report)
+    print('\n\n')
+
+    if errors:
+        raise ValidationError('Validation failed')
+
+    return catalog
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Utilities for cataloging feedstocks for LEAP')
+    parser.add_argument(
+        '--path', type=str, help='Path to the feedstocks input YAML file', required=True
+    )
+    parser.add_argument('--output', type=str, help='Path to the output directory', required=True)
+    args = parser.parse_args()
+    feedstocks = collect_feedstocks(args.path)
+    catalog = validate_feedstocks(feedstocks=feedstocks)
+    output = upath.UPath(args.output).resolve() / 'output'
+    output.mkdir(parents=True, exist_ok=True)
+
+    # write catalog to JSON file for use in the website
+    with open(f'{output}/consolidated-web-catalog.json', 'w') as f:
+        json.dump(catalog, f, indent=2, default=pydantic_core.to_jsonable_python)
+        print(f'Catalog written to {output}/consolidated-web-catalog.json')
+
+
+if __name__ == '__main__':
+    main()

--- a/leap_data_management_utils/catalog.py
+++ b/leap_data_management_utils/catalog.py
@@ -95,7 +95,6 @@ def collect_feedstocks(path: upath.UPath) -> list[upath.UPath]:
     url = convert_to_raw_github_url(path)
     if not (feedstocks := yaml.safe_load(upath.UPath(url).read_text())['feedstocks']):
         raise FileNotFoundError(f'No YAML files (.yaml or .yml) found in {path}')
-    print(feedstocks)
     return feedstocks
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,20 +23,32 @@ classifiers = [
 ]
 dependencies = [
     "apache-beam",
-    "google-cloud-bigquery",
-    "google-api-core",
-    "zarr",
-    "xarray",
-    "pangeo-forge-esgf",
-    "db_dtypes",
     "cftime",
+    "db_dtypes",
+    "google-api-core",
+    "google-cloud-bigquery",
     "pandas",
+    "pangeo-forge-esgf",
+    "pydantic-core",
+    "pydantic>=2",
+    "pyyaml",
+    "universal-pathlib",
+    "xarray",
+    "zarr",
 ]
 
 [project.optional-dependencies]
 test = [
     "pre-commit",
 ]
+
+
+[project.scripts]
+leap-catalog = "leap_data_management_utils.catalog:main"
+
+
+[tool.setuptools.packages.find]
+include = ["leap_data_management_utils*"]
 
 [tool.setuptools_scm]
 write_to = "leap_data_management_utils/_version.py"


### PR DESCRIPTION
this PR adds a few cataloging functionality via the `leap-catalog` command: 


```console
❯ leap-catalog --help                                                                                                                                                                                              
usage: leap-catalog [-h] {validate,generate} ...

Utilities for cataloging feedstocks for LEAP

positional arguments:
  {validate,generate}  sub-command help
    validate           Validate the feedstocks
    generate           Generate the catalog

options:
  -h, --help           show this help message and exit
```

one can 

- validate a single feedstock/catalog.yaml via 

```console 
❯ leap-catalog validate --single https://github.com/leap-stc/proto_feedstock/blob/main/feedstock/catalog.yaml                                                                                                      
✅ Valid feedstock: (1)
  📂 https://github.com/leap-stc/proto_feedstock/blob/main/feedstock/catalog.yaml

```

- generate a set of feedstocks and generate the `consolidated-web-catalog.json` via 

```console 
❯ leap-catalog generate --path https://raw.githubusercontent.com/leap-stc/data-management/staging/catalog/input.yaml --output /tmp/                                                                             
['https://github.com/carbonplan/ocean-carbon-sink-data-feedstock/blob/main/feedstock/catalog.yaml']
✅ Valid feedstocks: (1)
  📂 https://github.com/carbonplan/ocean-carbon-sink-data-feedstock/blob/main/feedstock/catalog.yaml

❌ Invalid feedstocks: (0)
  🚀 None found

Catalog written to /private/tmp/output/consolidated-web-catalog.json
```


Cc @norlandrhagen, @jbusecke 
