### PR TITLE
Add 'pass-through' option to copy stage

### DIFF
--- a/leap_data_management_utils/data_management_transforms.py
+++ b/leap_data_management_utils/data_management_transforms.py
@@ -124,12 +124,13 @@ class Copy(beam.PTransform):
 
     def _copy(self, store: zarr.storage.FSStore) -> zarr.storage.FSStore:
         import os
-        import zarr
+
         import gcsfs
+        import zarr
 
         # We do need the gs:// prefix?
         # TODO: Determine this dynamically from zarr.storage.FSStore
-        source = f"gs://{os.path.normpath(store.path)}/"  # FIXME more elegant. `.copytree` needs trailing slash
+        source = f'gs://{os.path.normpath(store.path)}/'  # FIXME more elegant. `.copytree` needs trailing slash
         if self.target is False:
             # dont do anything
             return store
@@ -141,7 +142,7 @@ class Copy(beam.PTransform):
             return zarr.storage.FSStore(self.target)
 
     def expand(self, pcoll: beam.PCollection) -> beam.PCollection:
-        return pcoll | "Copying Store" >> beam.Map(self._copy)
+        return pcoll | 'Copying Store' >> beam.Map(self._copy)
 
 
 @dataclass


### PR DESCRIPTION
If `target=False` is set on the Copy stage, it will do nothing and return the store input.

This is logic moved from https://github.com/leap-stc/proto_feedstock/pull/27