### PR TITLE
Get git hash url from gh actions + inject actions url by default

### DIFF
--- a/leap_data_management_utils/data_management_transforms.py
+++ b/leap_data_management_utils/data_management_transforms.py
@@ -71,13 +71,8 @@ def get_github_commit_url() -> str:
         except Exception as e:
             print(f"Getting git_url_hash failed with {e}")
             git_url_hash = "none"
-        # Output the GitHub commit URL
-        return git_url_hash
-
-    except subprocess.CalledProcessError as e:
-        print('Error executing Git command:', e)
-        return None
-
+    # Output the GitHub commit URL
+    return git_url_hash
 
 def get_catalog_store_urls(catalog_yaml_path: str) -> dict[str, str]:
     with open(catalog_yaml_path) as f:

--- a/leap_data_management_utils/data_management_transforms.py
+++ b/leap_data_management_utils/data_management_transforms.py
@@ -22,7 +22,7 @@ def get_github_actions_url() -> str:
         repository = os.getenv('GITHUB_REPOSITORY')
         run_id = os.getenv('GITHUB_RUN_ID')
         commit_hash = os.getenv('GITHUB_SHA')
-        
+
         if server_url and repository and run_id and commit_hash:
             return f"{server_url}/{repository}/actions/runs/{run_id}"
         else:
@@ -32,7 +32,7 @@ def get_github_actions_url() -> str:
 def get_github_commit_url() -> str:
     """Get the GitHub commit URL for the current commit"""
     # Get GitHub Server URL
-    
+
 
     # check if this is running from within a github action
     if os.getenv('GITHUB_ACTIONS') == 'true':
@@ -41,7 +41,7 @@ def get_github_commit_url() -> str:
         repository = os.getenv('GITHUB_REPOSITORY')
         run_id = os.getenv('GITHUB_RUN_ID')
         commit_hash = os.getenv('GITHUB_SHA')
-        
+
         if server_url and repository and run_id and commit_hash:
             git_url_hash = f"{server_url}/{repository}/commit/{commit_hash}"
         else:
@@ -57,13 +57,13 @@ def get_github_commit_url() -> str:
             repo_origin_url = subprocess.check_output(
                 ['git', 'config', '--get', 'remote.origin.url'], text=True
             ).strip()
-    
+
             # Extract the repository path from the remote URL
             repository_path = repo_origin_url.split('github.com/')[-1].replace('.git', '')
-    
+
             # Get the current commit SHA
             commit_sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip()
-    
+
             # Construct the GitHub commit URL
             git_url_hash = f'{github_server_url}/{repository_path}/commit/{commit_sha}'
 

--- a/leap_data_management_utils/data_management_transforms.py
+++ b/leap_data_management_utils/data_management_transforms.py
@@ -232,7 +232,7 @@ class InjectAttrs(beam.PTransform):
             timestamp = datetime.now(timezone.utc).isoformat()
             provenance_dict = {
                 'pangeo_forge_build_git_hash': git_url_hash,
-                'pangeo_forge_gh_actions_url': gh_actions_url
+                'pangeo_forge_gh_actions_url': gh_actions_url,
                 'pangeo_forge_build_timestamp': timestamp,
             }
             self.inject_attrs.update(provenance_dict)

--- a/leap_data_management_utils/data_management_transforms.py
+++ b/leap_data_management_utils/data_management_transforms.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import apache_beam as beam
+import os
 import zarr
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery

--- a/leap_data_management_utils/data_management_transforms.py
+++ b/leap_data_management_utils/data_management_transforms.py
@@ -28,6 +28,8 @@ def get_github_actions_url() -> str:
         else:
             print("One or more environment variables are missing.")
             return "none"
+    else:
+        return "none"
 
 def get_github_commit_url() -> str:
     """Get the GitHub commit URL for the current commit"""
@@ -66,7 +68,9 @@ def get_github_commit_url() -> str:
 
             # Construct the GitHub commit URL
             git_url_hash = f'{github_server_url}/{repository_path}/commit/{commit_sha}'
-
+        except Exception as e:
+            print(f"Getting git_url_hash failed with {e}")
+            git_url_hash = "none"
         # Output the GitHub commit URL
         return git_url_hash
 

--- a/leap_data_management_utils/data_management_transforms.py
+++ b/leap_data_management_utils/data_management_transforms.py
@@ -14,6 +14,7 @@ from ruamel.yaml import YAML
 
 yaml = YAML(typ='safe')
 
+
 def get_github_actions_url() -> str:
     """Return the url of the gh action run"""
     if os.getenv('GITHUB_ACTIONS') == 'true':
@@ -24,17 +25,17 @@ def get_github_actions_url() -> str:
         commit_hash = os.getenv('GITHUB_SHA')
 
         if server_url and repository and run_id and commit_hash:
-            return f"{server_url}/{repository}/actions/runs/{run_id}"
+            return f'{server_url}/{repository}/actions/runs/{run_id}'
         else:
-            print("One or more environment variables are missing.")
-            return "none"
+            print('One or more environment variables are missing.')
+            return 'none'
     else:
-        return "none"
+        return 'none'
+
 
 def get_github_commit_url() -> str:
     """Get the GitHub commit URL for the current commit"""
     # Get GitHub Server URL
-
 
     # check if this is running from within a github action
     if os.getenv('GITHUB_ACTIONS') == 'true':
@@ -45,13 +46,15 @@ def get_github_commit_url() -> str:
         commit_hash = os.getenv('GITHUB_SHA')
 
         if server_url and repository and run_id and commit_hash:
-            git_url_hash = f"{server_url}/{repository}/commit/{commit_hash}"
+            git_url_hash = f'{server_url}/{repository}/commit/{commit_hash}'
         else:
-            print("Could not construct git_url_hash. One or more environment variables are missing.")
-            git_url_hash = "none"
+            print(
+                'Could not construct git_url_hash. One or more environment variables are missing.'
+            )
+            git_url_hash = 'none'
 
     else:
-        #TODO: If the above fails, maybe still try this? Even though that would be a really rare case?
+        # TODO: If the above fails, maybe still try this? Even though that would be a really rare case?
         print('Fallback: Calling git via subprocess')
         github_server_url = 'https://github.com'
         # Get the repository's remote origin URL
@@ -69,10 +72,11 @@ def get_github_commit_url() -> str:
             # Construct the GitHub commit URL
             git_url_hash = f'{github_server_url}/{repository_path}/commit/{commit_sha}'
         except Exception as e:
-            print(f"Getting git_url_hash failed with {e}")
-            git_url_hash = "none"
+            print(f'Getting git_url_hash failed with {e}')
+            git_url_hash = 'none'
     # Output the GitHub commit URL
     return git_url_hash
+
 
 def get_catalog_store_urls(catalog_yaml_path: str) -> dict[str, str]:
     with open(catalog_yaml_path) as f:

--- a/leap_data_management_utils/data_management_transforms.py
+++ b/leap_data_management_utils/data_management_transforms.py
@@ -1,13 +1,13 @@
 # Note: All of this code was written by Julius Busecke and copied from this feedstock:
 # https://github.com/leap-stc/cmip6-leap-feedstock/blob/main/feedstock/recipe.py#L262
 
+import os
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional
 
 import apache_beam as beam
-import os
 import zarr
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery


### PR DESCRIPTION
This is an attempt to fix an issue with the github url not being correctly injected into the CMIP6 datasets [here](https://github.com/leap-stc/cmip6-leap-feedstock/pull/142).
As part of this I also added the injection of a gh actions link by default.

As soon as https://github.com/leap-stc/cmip6-leap-feedstock/pull/142 passes on this PR, branch we can merge and release.
