### PR TITLE
Refactor dependencies in `pyproject.toml`

### DIFF
--- a/.github/workflows/catalog-ci.yaml
+++ b/.github/workflows/catalog-ci.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install package
         run: |
-          python -m pip install .
+          python -m pip install ".[catalog]"
 
       - name: Validate Feedstocks and Generate Catalog
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: "0 13 * * 1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     defaults:

--- a/leap_data_management_utils/catalog.py
+++ b/leap_data_management_utils/catalog.py
@@ -6,7 +6,9 @@ import pydantic
 import pydantic_core
 import requests
 import upath
-import yaml
+from ruamel.yaml import YAML
+
+yaml = YAML(typ='safe')
 
 
 def s3_to_https(s3_url: str) -> str:
@@ -80,10 +82,10 @@ class Feedstock(pydantic.BaseModel):
 
     @classmethod
     def from_yaml(cls, path: str):
-        content = yaml.safe_load(upath.UPath(path).read_text())
+        content = yaml.load(upath.UPath(path).read_text())
         if 'ncviewjs:meta_yaml_url' in content:
             meta_url = convert_to_raw_github_url(content['ncviewjs:meta_yaml_url'])
-            meta = yaml.safe_load(upath.UPath(meta_url).read_text())
+            meta = yaml.load(upath.UPath(meta_url).read_text())
             content = content | meta
         data = cls.model_validate(content)
         return data
@@ -113,7 +115,7 @@ def collect_feedstocks(path: upath.UPath) -> list[upath.UPath]:
     """Collects all the datasets in the given directory."""
 
     url = convert_to_raw_github_url(path)
-    if not (feedstocks := yaml.safe_load(upath.UPath(url).read_text())['feedstocks']):
+    if not (feedstocks := yaml.load(upath.UPath(url).read_text())['feedstocks']):
         raise FileNotFoundError(f'No YAML files (.yaml or .yml) found in {path}')
     return feedstocks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,21 +30,34 @@ dependencies = [
 
 [project.optional-dependencies]
 
-pangeo-forge=[  "db_dtypes",
+pangeo-forge=[
+    "db_dtypes",
     "google-api-core",
     "google-cloud-bigquery",
     "pandas",
     "pangeo-forge-esgf",
-    "pangeo-forge-recipes", "apache-beam"]
-catalog = ["pydantic>=2","universal-pathlib", "pydantic-core"]
+    "pangeo-forge-recipes",
+    "apache-beam",
+    ]
+
+catalog = [
+    "pydantic>=2",
+    "universal-pathlib",
+    "pydantic-core",
+    ]
+
+
+
+complete = ["leap-data-leap_data_management_utils[pangeo-forge,catalog]"]
 test = [
-    "pytest"
+    "pytest",
+    "leap-data-leap_data_management_utils[complete]",
 ]
+
 dev = [
     "leap-data-leap_data_management_utils[test]",
-    "pre-commit"
+    "pre-commit",
 ]
-complete = ["leap-data-leap_data_management_utils[pangeo-forge,catalog]"]
 
 [project.scripts]
 leap-catalog = "leap_data_management_utils.catalog:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,33 +22,29 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "apache-beam",
     "cftime",
-    "db_dtypes",
-    "google-api-core",
-    "google-cloud-bigquery",
-    "pandas",
-    "pangeo-forge-esgf",
-    "pangeo-forge-recipes",
-    "pydantic-core",
-    "pydantic>=2",
-    "pyyaml",
     "ruamel.yaml",
-    "universal-pathlib",
     "xarray",
     "zarr",
 ]
 
 [project.optional-dependencies]
+
+pangeo-forge=[  "db_dtypes",
+    "google-api-core",
+    "google-cloud-bigquery",
+    "pandas",
+    "pangeo-forge-esgf",
+    "pangeo-forge-recipes", "apache-beam"]
+catalog = ["pydantic>=2","universal-pathlib", "pydantic-core"]
 test = [
     "pytest"
 ]
-
 dev = [
     "leap-data-leap_data_management_utils[test]",
     "pre-commit"
 ]
-
+complete = ["leap-data-leap_data_management_utils[pangeo-forge,catalog]"]
 
 [project.scripts]
 leap-catalog = "leap_data_management_utils.catalog:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,14 +48,14 @@ catalog = [
 
 
 
-complete = ["leap-data-leap_data_management_utils[pangeo-forge,catalog]"]
+complete = ["leap-data-management-utils[pangeo-forge,catalog]"]
 test = [
     "pytest",
-    "leap-data-leap_data_management_utils[pangeo-forge,catalog]",
+    "leap-data-management-utils[complete]",
 ]
 
 dev = [
-    "leap-data-leap_data_management_utils[test]",
+    "leap-data-management-utils[test]",
     "pre-commit",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ catalog = [
 complete = ["leap-data-leap_data_management_utils[pangeo-forge,catalog]"]
 test = [
     "pytest",
-    "leap-data-leap_data_management_utils[complete]",
+    "leap-data-leap_data_management_utils[pangeo-forge,catalog]",
 ]
 
 dev = [


### PR DESCRIPTION
- Refactored dependencies in `pyproject.toml`. The original monolithic list has been split into optional dependencies under 'pangeo-forge' and 'catalog'. 
- Added 'complete' directive under optional dependencies for encapsulating all dependencies.

I believe these changes will facilitate better dependecies management (for e.g. i would like to use the cataloging features without needing to install apache-beam, etc...)